### PR TITLE
sonos-control: fix +/-N Vol and "playpause/toggle" 

### DIFF
--- a/dist/sonos-control.js
+++ b/dist/sonos-control.js
@@ -64,10 +64,10 @@ module.exports = function (RED) {
         else if (payload === "mute" || payload === "unmute" || payload === "vol_up" || payload === "vol_down" || payload === "vol+" || payload === "vol+") {
             newPayload = { volume: payload };
         }
-        else if (payload.indexOf("+") > 0 && parseInt(payload) > 0 && parseInt(payload) <= 100) {
+        else if (payload.indexOf("+") >= 0 && parseInt(payload) > 0 && parseInt(payload) <= 100) {
             newPayload = { volume: "vol_up", volstep: parseInt(payload) };
         }
-        else if (payload.indexOf("-") && parseInt(payload) < 0 && parseInt(payload) >= -100) {
+        else if (payload.indexOf("-") >= 0 && parseInt(payload) < 0 && parseInt(payload) >= -100) {
             newPayload = { volume: "vol_down", volstep: -parseInt(payload) };
         }
         else if (!isNaN(parseInt(payload)) && parseInt(payload) >= 0 && parseInt(payload) <= 100) {
@@ -131,7 +131,7 @@ module.exports = function (RED) {
                         node.status({ fill: "red", shape: "dot", text: "invalid current state retrieved" });
                         return;
                     }
-                    if (state.playerState === "playing") {
+                    if (state.playbackState.toUpperCase() === "PLAYING") {
                         client.pause(function (err, result) {
                             helper.handleSonosApiRequest(node, err, result, msg, "paused", null, send, done);
                         });

--- a/src/sonos-control.ts
+++ b/src/sonos-control.ts
@@ -92,10 +92,10 @@ module.exports = function (RED) {
 		else if (payload === "mute" || payload === "unmute" || payload === "vol_up" || payload === "vol_down" || payload === "vol+" || payload === "vol+") {
 			newPayload = { volume: payload };
 		}
-		else if (payload.indexOf("+") > 0 && parseInt(payload) > 0 && parseInt(payload) <= 100) {
+		else if (payload.indexOf("+") >= 0 && parseInt(payload) > 0 && parseInt(payload) <= 100) {
 			newPayload = { volume: "vol_up", volstep: parseInt(payload) };
 		}
-		else if (payload.indexOf("-") && parseInt(payload) < 0 && parseInt(payload) >= -100) {
+		else if (payload.indexOf("-") >= 0 && parseInt(payload) < 0 && parseInt(payload) >= -100) {
 			newPayload = { volume: "vol_down", volstep: -parseInt(payload) };
 		}
 		else if (!isNaN(parseInt(payload)) && parseInt(payload) >= 0 && parseInt(payload) <= 100) {
@@ -165,7 +165,7 @@ module.exports = function (RED) {
 						return;
 					}
 
-					if (state.playerState === "playing") {
+					if (state.playbackState.toUpperCase() === "PLAYING") {
 						client.pause((err, result) => {
 							helper.handleSonosApiRequest(node, err, result, msg, "paused", null, send, done);
 						});


### PR DESCRIPTION
Hi,
First of all, NICE WORK!

I had an issue with the +/-N to increase or decrease the volume by N. 
-N was not working if '-' was the first character in payload (IndexOf() returns -1 if the value to search for never occurs.)
In my node-red flow, I use the toggle/playpause feature. Since the wrong value in state was checked, it was only possible to play music.

best regards
Bastian