### PR TITLE
sonos-status accepts optional input msg.player like sonos-control etc.

### DIFF
--- a/dist/sonos-status.html
+++ b/dist/sonos-status.html
@@ -70,6 +70,15 @@
     <p>
         A node to retrieve current track info, volume, mute, playing state, etc. upon triggered
     </p>
+	
+    <h2>Inputs</h2>
+
+    <dl class="message-properties">
+        <dt>msg.player<span class="property-type">string</span></dt>
+        <dd> Sonos playername (e.g. Living room)</dd>
+    </dl>
+	
+	
     <h2>Outputs</h2>
     
     <dl class="message-properties">

--- a/dist/sonos-status.js
+++ b/dist/sonos-status.js
@@ -21,6 +21,8 @@ module.exports = function status(RED) {
         });
     }
     function getSonosCurrentState(node, msg, player, configNode) {
+		if (msg.player !== null && msg.player !== undefined && msg.player)
+            player = msg.player;
         var client = new SonosClient_1.default(player, configNode);
         if (client === null || client === undefined) {
             node.status({ fill: "red", shape: "dot", text: "sonos client is null" });

--- a/src/sonos-status.html
+++ b/src/sonos-status.html
@@ -70,6 +70,14 @@
     <p>
         A node to retrieve current track info, volume, mute, playing state, etc. upon triggered
     </p>
+	
+    <h2>Inputs</h2>
+
+    <dl class="message-properties">
+        <dt>msg.player<span class="property-type">string</span></dt>
+        <dd> Sonos playername (e.g. Living room)</dd>
+    </dl>
+	
     <h2>Outputs</h2>
     
     <dl class="message-properties">

--- a/src/sonos-status.ts
+++ b/src/sonos-status.ts
@@ -26,6 +26,9 @@ module.exports = function status(RED) {
 
 	function getSonosCurrentState(node, msg, player, configNode:ConfigNode) 
 	{
+		if (msg.player !== null && msg.player !== undefined && msg.player)
+            player = msg.player;
+		
 		var client = new SonosClient(player, configNode);
 		if (client === null || client === undefined) {
 			node.status({fill:"red", shape:"dot", text:"sonos client is null"});


### PR DESCRIPTION
Hi Benjamin,

me again ;)
I've added optional msg.player input to sonos-status like sonos-control, etc.
Now it is possible to switch the player in UI and show the right states. 

Greetings, and have a nice weekend
Bastian